### PR TITLE
Add solution field to problem

### DIFF
--- a/app/assets/javascripts/toggle_element_class.js
+++ b/app/assets/javascripts/toggle_element_class.js
@@ -1,0 +1,6 @@
+
+function toggleElementClass(elementId, className) {
+	const element = document.getElementById(elementId);
+	element.classList.toggle(className);
+}
+

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -154,6 +154,7 @@ class ProblemsController < ApplicationController
         :example_output,
         :hint,
         :source,
+        :solution,
         :limit,
         :page,
         :visible_state,

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -155,6 +155,7 @@ class ProblemsController < ApplicationController
         :hint,
         :source,
         :solution,
+        :display_solution,
         :limit,
         :page,
         :visible_state,

--- a/app/views/problems/_form.html.erb
+++ b/app/views/problems/_form.html.erb
@@ -93,6 +93,11 @@
   </div>
 
   <div class="form-group">
+    <%= f.label :display_solution %>
+    <%= f.select :display_solution, [["Hidden", false], ["Show", true]], {}, {:class => 'form-control flat'} %>
+  </div>
+
+  <div class="form-group">
     <%= f.label :solution %>
         <%= f.text_area :solution, :class => 'form-control flat', :rows => '9' %>
   </div>

--- a/app/views/problems/_form.html.erb
+++ b/app/views/problems/_form.html.erb
@@ -92,6 +92,11 @@
     </div>
   </div>
 
+  <div class="form-group">
+    <%= f.label :solution %>
+        <%= f.text_area :solution, :class => 'form-control flat', :rows => '9' %>
+  </div>
+
   <% if @problem.problem_type == 1 %>
     <div class="form-group">
       <%= f.label :sjcode, raw("Special Judge Code (output 0 for AC, otherwise WA)<br><code>argv[1]: path to testee output</code>  <code>argv[2]: path to testdata input</code>  <code>argv[3]: path to testdata output</code>  <code>argv[4]: language (c++98/c++11/c++14/c++17/c90/c99/c11/haskell/python2/python3)</code>  <code>argv[5]: path to source code</code>") %>

--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -175,6 +175,15 @@
 
 <div class="panel panel-default">
   <div class="panel-heading">
+    <h1 class="panel-title">Solution</h1>
+  </div>
+  <div class="panel-body">
+    <%= markdown(@problem.solution) %>
+  </div>
+</div>
+
+<div class="panel panel-default">
+  <div class="panel-heading">
     <h1 class="panel-title">Subtasks</h1>
   </div>
   <table class="table table-hover table-striped table-condensed">

--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -175,10 +175,10 @@
 
 <% if (current_user and current_user.admin?) or @problem.display_solution %>
   <div class="panel panel-default">
-    <div class="panel-heading">
-      <h1 class="panel-title">Solution</h1>
+    <div class="panel-heading" onclick="toggleElementClass('solution-body', 'hidden')">
+      <h1 class="panel-title">Solution (Click to toggle)</h1>
     </div>
-    <div class="panel-body">
+    <div class="panel-body hidden" id="solution-body">
       <%= markdown(@problem.solution) %>
     </div>
   </div>

--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -173,14 +173,16 @@
   </div>
 </div>
 
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <h1 class="panel-title">Solution</h1>
+<% if (current_user and current_user.admin?) or @problem.display_solution %>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h1 class="panel-title">Solution</h1>
+    </div>
+    <div class="panel-body">
+      <%= markdown(@problem.solution) %>
+    </div>
   </div>
-  <div class="panel-body">
-    <%= markdown(@problem.solution) %>
-  </div>
-</div>
+<% end %>
 
 <div class="panel panel-default">
   <div class="panel-heading">

--- a/db/migrate/20210706141243_add_problem_solution_field.rb
+++ b/db/migrate/20210706141243_add_problem_solution_field.rb
@@ -1,0 +1,5 @@
+class AddProblemSolutionField < ActiveRecord::Migration
+  def change
+	add_column :problems, :solution, :text, :limit => 65535
+  end
+end

--- a/db/migrate/20210717062442_create_solution_display_option.rb
+++ b/db/migrate/20210717062442_create_solution_display_option.rb
@@ -1,0 +1,5 @@
+class CreateSolutionDisplayOption < ActiveRecord::Migration
+  def change
+	add_column :problems, :display_solution, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210706141243) do
+ActiveRecord::Schema.define(version: 20210717062442) do
+
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
     t.text     "body",          limit: 65535
@@ -160,23 +161,24 @@ ActiveRecord::Schema.define(version: 20210706141243) do
   add_index "posts", ["user_id"], name: "index_posts_on_user_id", using: :btree
 
   create_table "problems", force: :cascade do |t|
-    t.string   "name",           limit: 255
-    t.text     "description",    limit: 65535
-    t.text     "source",         limit: 65535
+    t.string   "name",             limit: 255
+    t.text     "description",      limit: 65535
+    t.text     "source",           limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "input",          limit: 65535
-    t.text     "output",         limit: 65535
-    t.text     "example_input",  limit: 65535
-    t.text     "example_output", limit: 65535
-    t.text     "hint",           limit: 65535
-    t.integer  "visible_state",  limit: 4,        default: 0
-    t.integer  "problem_type",   limit: 4
-    t.text     "sjcode",         limit: 16777215
-    t.text     "interlib",       limit: 16777215
-    t.integer  "old_pid",        limit: 4
-    t.string   "group",          limit: 255
-    t.text     "solution",       limit: 65535
+    t.text     "input",            limit: 65535
+    t.text     "output",           limit: 65535
+    t.text     "example_input",    limit: 65535
+    t.text     "example_output",   limit: 65535
+    t.text     "hint",             limit: 65535
+    t.integer  "visible_state",    limit: 4,        default: 0
+    t.integer  "problem_type",     limit: 4
+    t.text     "sjcode",           limit: 16777215
+    t.text     "interlib",         limit: 16777215
+    t.integer  "old_pid",          limit: 4
+    t.string   "group",            limit: 255
+    t.text     "solution",         limit: 65535
+    t.boolean  "display_solution",                  default: false
   end
 
   add_index "problems", ["name"], name: "index_problems_on_name", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200118041340) do
-
+ActiveRecord::Schema.define(version: 20210706141243) do
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
     t.text     "body",          limit: 65535
@@ -176,6 +175,8 @@ ActiveRecord::Schema.define(version: 20200118041340) do
     t.text     "sjcode",         limit: 16777215
     t.text     "interlib",       limit: 16777215
     t.integer  "old_pid",        limit: 4
+    t.string   "group",          limit: 255
+    t.text     "solution",       limit: 65535
   end
 
   add_index "problems", ["name"], name: "index_problems_on_name", using: :btree


### PR DESCRIPTION
Add solution field to problem.

Display solution in problem's show page, with collapsed as default. Click on the title bar of solution can expand the solution of the problem.

Add control for showing solution or not.