### PR TITLE
Fix user with username with dot can't get user page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Tioj::Application.routes.draw do
 
   resources :judge_servers
   resources :submissions
-  resources :users
+  resources :users, constraints: { id: /.+/ }
   resources :posts do
     resources :comments
   end


### PR DESCRIPTION
Can not see the user's page whose username contains a dot.

Change the constraint of matching user's id to fix it.