### PR TITLE
Change config to fix routing issue

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,12 @@ Rails.application.routes.draw do
 
   devise_for :users, :controllers => {:registrations => "registrations", :passwords => "users/passwords"}
   devise_for :admin_users, ActiveAdmin::Devise.config
+
+  scope 'admin' do
+    resources :users, controller: 'admin/users', constraints: { id: /[^\/]+/ }
+  end
   ActiveAdmin.routes(self)
+
   #resources :limits
   resources :problems do
     resources :testdata do


### PR DESCRIPTION
As in https://github.com/TIOJ-INFOR-Online-Judge/tioj/issues/22, when an user's username contains a dot ('.'), we can not visit it via the routing path `/admin/users/:username` in the ActiveAdmin page. The fix comes from the same file, modifying the constraints of parameter. See the same file in commit af4364f38be61e3a22c982f4c72342895bc65636.