### PR TITLE
Fix default summary compiler selection

### DIFF
--- a/app/views/problems/_form.html.erb
+++ b/app/views/problems/_form.html.erb
@@ -341,7 +341,7 @@
 
   <div class="form-group visibility-summary visibility-summary-custom">
     <%= f.label :summary_compiler_id, "Summary Compiler" %>
-    <%= f.select :summary_compiler_id, options_for_select(@compiler.map{|x| [x.description, x.id]}, @problem.specjudge_compiler_id || @compiler[0].id),
+    <%= f.select :summary_compiler_id, options_for_select(@compiler.map{|x| [x.description, x.id]}, @problem.summary_compiler_id || @compiler[0].id),
         {}, {class: 'form-control flat'} %>
   </div>
   <div class="form-group visibility-summary visibility-summary-custom">


### PR DESCRIPTION
When `specjudge_compiler` and `summary_compiler` are different, the default "selected" option for `summary_compiler` will be wrong. I found myself accidentally updated `summary compiler` from `python` to `c++` and got ER verdict for many times, so here's the PR that fix the typo.