### PR TITLE
Fix unintended leaking of `first_ac`.

### DIFF
--- a/app/helpers/contests_helper.rb
+++ b/app/helpers/contests_helper.rb
@@ -104,7 +104,7 @@ module ContestsHelper
       orig_state = res[key][-1]&.dig(:state)
       new_state = func.call(sub, start_time, orig_state, is_waiting)
       res[key] << {timestamp: submission_rel_timestamp(sub, start_time), state: new_state} unless new_state.nil?
-      first_ac[sub.problem_id] = first_ac.fetch(sub.problem_id, sub.user_id) if sub.result == 'AC'
+      first_ac[sub.problem_id] = first_ac.fetch(sub.problem_id, sub.user_id) if sub.result == 'AC' && sub.created_at < freeze_start
     end
     res.delete_if { |key, value| value.empty? }
     res.each_value {|x| x.each {|item| item[:state].pop}} if rule == 'ioi_new'


### PR DESCRIPTION
Fix unintended leaking of `first_ac`. The frozen scoreboard should ignore `AC` after `freeze_start`.