### PR TITLE
Disable mathjax in problem samples

### DIFF
--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -155,7 +155,7 @@
           <h1 class="panel-title pull-left">Sample Input <%= index + 1 %></h1>
           <button class="btn btn-default btn-xs pull-right copy-group-btn"> copy </button>
         </div>
-        <div class="panel-body code-input copy-group-code" style="font-size:15px;line-height:18px;"><%= raw sample.input.gsub(/\n/, '<br/>') %></div>
+        <div class="mathjax_ignore panel-body code-input copy-group-code" style="font-size:15px;line-height:18px;"><%= raw sample.input.gsub(/\n/, '<br/>') %></div>
       </div>
     </div>
     <div class="col-md-6">
@@ -164,7 +164,7 @@
           <h1 class="panel-title pull-left">Sample Output <%= index + 1 %></h1>
           <button class="btn btn-default btn-xs pull-right copy-group-btn"> copy </button>
         </div>
-        <div class="panel-body code-input copy-group-code" style="font-size:15px;line-height:18px;"><%= raw sample.output.gsub(/\n/, '<br/>') %></div>
+        <div class="mathjax_ignore panel-body code-input copy-group-code" style="font-size:15px;line-height:18px;"><%= raw sample.output.gsub(/\n/, '<br/>') %></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
If a sample contains several dollar sign symbols `$`, it would be mistakenly rendered by mathjax.
Adding `class=mathjax_ignore` would disable mathjax in that section (but not `class=tex2jax_ignore`!), see https://docs.mathjax.org/en/latest/options/document.html