### PR TITLE
Use pre to display sample

### DIFF
--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -262,6 +262,7 @@ class ProblemsController < ApplicationController
         :problem_id,
         :input,
         :output,
+        :display_type,
         :_destroy
       ],
       compiler_ids: [],
@@ -272,7 +273,7 @@ class ProblemsController < ApplicationController
         :constraints,
         :score,
         :_destroy
-      ]
+      ],
     )
   end
 end

--- a/app/models/sample_testdatum.rb
+++ b/app/models/sample_testdatum.rb
@@ -2,12 +2,13 @@
 #
 # Table name: sample_testdata
 #
-#  id         :bigint           not null, primary key
-#  problem_id :bigint
-#  input      :text(16777215)
-#  output     :text(16777215)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id           :bigint           not null, primary key
+#  problem_id   :bigint
+#  input        :text(16777215)
+#  output       :text(16777215)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  display_type :integer          default(0), not null
 #
 # Indexes
 #
@@ -18,4 +19,5 @@ class SampleTestdatum < ActiveRecord::Base
   default_scope { order('id ASC') }
 
   belongs_to :problem
+  enum :display_type, {plaintext: 0, markdown: 1}, prefix: :display
 end

--- a/app/views/problems/_form.html.erb
+++ b/app/views/problems/_form.html.erb
@@ -86,6 +86,8 @@
           <%= t.label :output, "Sample Output", class: "sample_output" %>
           <%= t.link_to_remove "Remove this sample testdatum", class: "btn btn-danger pull-right", name: "testdatum_remove" %>
           <%= t.text_area :output, class: 'form-control flat code-input', rows: '7' %>
+          <%= t.label :display_type, "Sample Display Type" %>
+          <%= t.select :display_type, SampleTestdatum.display_types.keys.map{|key| [key, key]}, {}, {class: 'form-control flat'} %>
         </div>
       </div>
     </div>

--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -156,7 +156,7 @@
           <button class="btn btn-default btn-xs pull-right copy-group-btn"> copy </button>
         </div>
         <div class="panel-body">
-          <pre class="code-input copy-group-code" style="font-size:15px;line-height:18px;border=0px;"><%= sample.input %></pre>
+          <pre class="code-input copy-group-code" style="font-size:15px;line-height:18px;border:0px;"><%= sample.input %></pre>
         </div>
       </div>
     </div>
@@ -167,7 +167,7 @@
           <button class="btn btn-default btn-xs pull-right copy-group-btn"> copy </button>
         </div>
         <div class="panel-body">
-          <pre class="code-input copy-group-code" style="font-size:15px;line-height:18px;border=0px;"><%= sample.output %></pre>
+          <pre class="code-input copy-group-code" style="font-size:15px;line-height:18px;border:0px;"><%= sample.output %></pre>
         </div>
       </div>
     </div>

--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -155,7 +155,9 @@
           <h1 class="panel-title pull-left">Sample Input <%= index + 1 %></h1>
           <button class="btn btn-default btn-xs pull-right copy-group-btn"> copy </button>
         </div>
-        <div class="mathjax_ignore panel-body code-input copy-group-code" style="font-size:15px;line-height:18px;"><%= raw sample.input.gsub(/\n/, '<br/>') %></div>
+        <div class="panel-body">
+          <pre class="code-input copy-group-code" style="font-size:15px;line-height:18px;border=0px;"><%= sample.input %></pre>
+        </div>
       </div>
     </div>
     <div class="col-md-6">
@@ -164,7 +166,9 @@
           <h1 class="panel-title pull-left">Sample Output <%= index + 1 %></h1>
           <button class="btn btn-default btn-xs pull-right copy-group-btn"> copy </button>
         </div>
-        <div class="mathjax_ignore panel-body code-input copy-group-code" style="font-size:15px;line-height:18px;"><%= raw sample.output.gsub(/\n/, '<br/>') %></div>
+        <div class="panel-body">
+          <pre class="code-input copy-group-code" style="font-size:15px;line-height:18px;border=0px;"><%= sample.output %></pre>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -153,10 +153,16 @@
       <div class="panel panel-default copy-group problem-copy-group">
         <div class="panel-heading">
           <h1 class="panel-title pull-left">Sample Input <%= index + 1 %></h1>
-          <button class="btn btn-default btn-xs pull-right copy-group-btn"> copy </button>
+          <% if sample.display_plaintext? %>
+            <button class="btn btn-default btn-xs pull-right copy-group-btn"> copy </button>
+          <% end %>
         </div>
         <div class="panel-body">
-          <pre class="code-input copy-group-code" style="font-size:15px;line-height:18px;border:0px;"><%= sample.input %></pre>
+          <% if sample.display_markdown? %>
+            <%= markdown(sample.input) %>
+          <% else %>
+            <pre class="code-input copy-group-code" style="font-size:15px;line-height:18px;border:0px;"><%= sample.input %></pre>
+          <% end %>
         </div>
       </div>
     </div>
@@ -164,10 +170,16 @@
       <div class="panel panel-default copy-group problem-copy-group">
         <div class="panel-heading">
           <h1 class="panel-title pull-left">Sample Output <%= index + 1 %></h1>
-          <button class="btn btn-default btn-xs pull-right copy-group-btn"> copy </button>
+          <% if sample.display_plaintext? %>
+            <button class="btn btn-default btn-xs pull-right copy-group-btn"> copy </button>
+          <% end %>
         </div>
         <div class="panel-body">
-          <pre class="code-input copy-group-code" style="font-size:15px;line-height:18px;border:0px;"><%= sample.output %></pre>
+          <% if sample.display_markdown? %>
+            <%= markdown(sample.output) %>
+          <% else %>
+            <pre class="code-input copy-group-code" style="font-size:15px;line-height:18px;border:0px;"><%= sample.output %></pre>
+          <% end %>
         </div>
       </div>
     </div>

--- a/db/migrate/20250218175247_add_display_type_to_sample_testdatum.rb
+++ b/db/migrate/20250218175247_add_display_type_to_sample_testdatum.rb
@@ -1,0 +1,5 @@
+class AddDisplayTypeToSampleTestdatum < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sample_testdata, :display_type, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_27_010819) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_18_175247) do
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "namespace"
     t.text "body", size: :medium
@@ -190,6 +190,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_27_010819) do
     t.boolean "online", default: false
   end
 
+  create_table "limits", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "time", default: 1000
+    t.integer "memory", default: 65536
+    t.integer "output", default: 65536
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "testdatum_id"
+  end
+
   create_table "old_submission_testdata_results", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "old_submission_id"
     t.integer "position"
@@ -277,6 +286,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_27_010819) do
     t.text "output", size: :medium
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "display_type", default: 0, null: false
     t.index ["problem_id"], name: "index_sample_testdata_on_problem_id"
   end
 

--- a/lib/tasks/sample_identify_non_plaintext.rake
+++ b/lib/tasks/sample_identify_non_plaintext.rake
@@ -8,7 +8,7 @@ namespace :sample do
        output LIKE ? OR output LIKE ? OR output LIKE ? OR output LIKE ?",
        '%$%$%', '%\\(%\\)%', '%\\\\[%\\\\]%', '%<%>%',
        '%$%$%', '%\\(%\\)%', '%\\\\[%\\\\]%', '%<%>%'
-    )
+    ).where(display_type: :plaintext)
     samples.each do |sample|
       puts "------------------------------------------------------------------------------"
       puts "In problem ##{sample.problem.id}, the following sample may require manual review."

--- a/lib/tasks/sample_identify_non_plaintext.rake
+++ b/lib/tasks/sample_identify_non_plaintext.rake
@@ -1,0 +1,47 @@
+namespace :sample do
+  desc "Identify those non-plaintext samples"
+  task identify_non_plaintext: :environment do
+
+
+    samples = SampleTestdatum.where(
+      "input LIKE ? OR input LIKE ? OR input LIKE ? OR input LIKE ? OR
+       output LIKE ? OR output LIKE ? OR output LIKE ? OR output LIKE ?",
+       '%$%$%', '%\\(%\\)%', '%\\\\[%\\\\]%', '%<%>%',
+       '%$%$%', '%\\(%\\)%', '%\\\\[%\\\\]%', '%<%>%'
+    )
+    samples.each do |sample|
+      puts "------------------------------------------------------------------------------"
+      puts "In problem ##{sample.problem.id}, the following sample may require manual review."
+      puts "Input:"
+      puts sample.input
+      puts "Output:"
+      puts sample.output
+
+      def detail_check(section, text)
+        escaped_text = ApplicationController.helpers.escape_once(text)
+        before_html = Nokogiri::HTML("<div>#{text}</div>")
+        after_html = Nokogiri::HTML("<pre>#{escaped_text}</pre>")
+        if escaped_text != text
+          puts "some html escape character detected in #{section}."
+        end
+        if before_html.text != after_html.text
+          puts "html-tag detected in #{section}:"
+          puts "before: #{before_html.text}"
+          puts "after: #{after_html.text}"
+        end
+
+        mathjax_regex = /(
+          \$(.*)\$ |        # $ ... $
+          \\\[(.*?)\\\] |   # \[ ... \]
+          \\\((.*?)\\\)     # \( ... \)
+        )/mx
+        matches = text.scan(mathjax_regex).map(&:first).compact
+        if matches.any?
+          puts "mathjax detected in #{section}: #{matches}"
+        end
+      end
+      detail_check("input", sample.input)
+      detail_check("output", sample.output)
+    end
+  end
+end


### PR DESCRIPTION
When there are trailing (edit: leading) spaces in the sample, using `div` would collapse them. Using just `pre` fixes that and removes the weird string gsub and raw, also prevents some sample to be mistakenly rendered as html elements. The copy functionality should be fine.

This might change some problem's look or break them.
- https://tioj.ck.tp.edu.tw/problems/1859
- https://tioj.ck.tp.edu.tw/problems/1159
- https://tioj.ck.tp.edu.tw/problems/1860/

Also, there is an issue about how we should deal with very long lines in samples.

Here's an image showing the difference:
![image](https://github.com/user-attachments/assets/c38f4c31-ee37-4dcc-815d-69fb46053d35)

