### PR TITLE
Fix obsolete systemd service options

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -255,8 +255,8 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
-StandardOut=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=tioj-judge
 ExecStart=/usr/bin/nice -n -10 tioj-judge -v
 ExecStop=/bin/kill -s INT \$MAINPID


### PR DESCRIPTION
This PR resolves the following warnings:

```
/etc/systemd/system/tioj-judge.service:7: Unknown key name 'StandardOut' in section 'Service', ignoring.
/etc/systemd/system/tioj-judge.service:8: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
/etc/systemd/system/tioj-judge.service:7: Unknown key name 'StandardOut' in section 'Service', ignoring.
/etc/systemd/system/tioj-judge.service:8: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
/etc/systemd/system/tioj-judge.service:7: Unknown key name 'StandardOut' in section 'Service', ignoring.
/etc/systemd/system/tioj-judge.service:8: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
```

The patch only applies to a fresh new install; existing service files may need to be updated manually though.