### PR TITLE
Replace "Requires" to "Wants" in systemd service

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -232,8 +232,8 @@ sudo sed -Ei "/^ *location \/[^a-z]/, /\}/ s|^ {8}|\0# |" /opt/nginx/conf/nginx.
 cat <<EOF | sudo tee /etc/systemd/system/nginx.service > /dev/null
 [Unit]
 Description=Nginx Server
-After=syslog.target
-Requires=network.target remote-fs.target nss-lookup.target mysql.service
+After=syslog.target network.target remote-fs.target nss-lookup.target mysql.service
+Wants=network.target remote-fs.target nss-lookup.target mysql.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Specifying `Requires=mysql.service` will make `nginx.service` deactivate itself when `mysql.service` is somehow dead or restarted. Ubuntu seems to have a daily auto-upgrade systemd timer and `mysql.service` could be restarted whenever it is upgraded.

Instead of `Requires=` we could use `Wants=` and `After=` to make it more robust.