### PR TITLE
Fix testdata_controller.rb:batch_create

### DIFF
--- a/app/controllers/testdata_controller.rb
+++ b/app/controllers/testdata_controller.rb
@@ -260,8 +260,8 @@ class TestdataController < ApplicationController
         end
         in_dest = "#{tmp_folder}/#{in_entry.name}"
         out_dest = "#{tmp_folder}/#{out_entry.name}"
-        in_entry.extract(in_dest)
-        out_entry.extract(out_dest)
+        in_entry.extract(in_dest, destination_directory: "/")
+        out_entry.extract(out_dest, destination_directory: "/")
         td_pair_dest << [in_dest, out_dest]
       end
     end


### PR DESCRIPTION
After updating rubyzip from 2.* to 3.*, `‎Zip::Entry::extract` defaults to extract under CWD. `unzip_testdata` then extract to `<tioj's working dir>/tmp/<tmp folder>`, while the temporary directory is still created in `/tmp`.